### PR TITLE
Remove Duplicate 'text-center' Class

### DIFF
--- a/components/PostCard.jsx
+++ b/components/PostCard.jsx
@@ -25,7 +25,7 @@ const PostCard = ({ post }) => (
       <Link href={`/post/${post.slug}`}>{post.title}</Link>
     </h1>
     <div className="block lg:flex text-center items-center justify-center mb-8 w-full">
-      <div className="flex items-center justify-center mb-4 lg:mb-0 w-full lg:w-auto mr-8 items-center">
+      <div className="flex items-center justify-center mb-4 lg:mb-0 w-full lg:w-auto mr-8">
         <Image
           unoptimized
           loader={grpahCMSImageLoader}


### PR DESCRIPTION
Hi,

I've removed a duplicate 'text-center' class from a JSX element in the code. The class was applied twice, causing unnecessary duplication of styling. This PR aims to improve code cleanliness and reduce potential conflicts.

Changes Made:
- Removed the duplicate 'text-center' class from components/PostCard.jsx

Before:
```jsx
<div className="flex items-center justify-center mb-4 lg:mb-0 w-full lg:w-auto mr-8 items-center">
  {/* Content */}
</div>
```

After: 
```jsx
<div className="flex  justify-center mb-4 lg:mb-0 w-full lg:w-auto mr-8 items-center">
  {/* Content */}
</div>
```
This change ensures that the element's styling is consistent while keeping the codebase cleaner. Please review and merge if it looks good.
Thumbs 👍 up for the tutorials.

Thank you!